### PR TITLE
Add variable for existing SSH keys

### DIFF
--- a/application/eu-central-1/env/main.tf
+++ b/application/eu-central-1/env/main.tf
@@ -12,6 +12,7 @@ module "application" {
   k8s_node_count           = "${var.k8s_node_count}"
   k8s_master_instance_type = "${var.k8s_master_instance_type}"
   k8s_node_instance_type   = "${var.k8s_node_instance_type}"
+  k8s_aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
 
   iam_cross_account_role_arn    = "${var.iam_cross_account_role_arn}"
   k8s_masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"

--- a/application/eu-central-1/env/variables.tf
+++ b/application/eu-central-1/env/variables.tf
@@ -29,3 +29,5 @@ variable "k8s_nodes_iam_policies_arns" {
 variable "k8s_master_instance_type" {}
 
 variable "k8s_node_instance_type" {}
+
+variable "k8s_aws_ssh_keypair_name" {}

--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -31,6 +31,8 @@ k8s_nodes_iam_policies_arns = [
 
 k8s_private_subnets = ["subnet-XXXX", "subnet-ZZZZ", "subnet-YYYY"] # List of private subnets (matching AZs) where to deploy the cluster (required if existing VPC is used)
 
+k8s_aws_ssh_keypair_name = "" # Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified)
+
 logs_not_resource = [] # List of resources that log police will use for NotResource, empty means that Resource * is set
 
 operations_aws_account_number = "123456789012" # AWS operations account number (without hyphens)

--- a/operations/eu-central-1/env/main.tf
+++ b/operations/eu-central-1/env/main.tf
@@ -13,6 +13,7 @@ module "operations" {
   k8s_node_count           = "${var.k8s_node_count}"
   k8s_master_instance_type = "${var.k8s_master_instance_type}"
   k8s_node_instance_type   = "${var.k8s_node_instance_type}"
+  k8s_aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
 
   k8s_masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"
   k8s_nodes_iam_policies_arns   = "${var.k8s_nodes_iam_policies_arns}"

--- a/operations/eu-central-1/env/variables.tf
+++ b/operations/eu-central-1/env/variables.tf
@@ -31,3 +31,5 @@ variable "k8s_masters_iam_policies_arns" {
 variable "k8s_nodes_iam_policies_arns" {
   type = "list"
 }
+
+variable "k8s_aws_ssh_keypair_name" {}

--- a/operations/eu-central-1/terraform.tfvars
+++ b/operations/eu-central-1/terraform.tfvars
@@ -44,6 +44,8 @@ k8s_nodes_iam_policies_arns = [
 
 k8s_private_subnets = ["subnet-XXXX", "subnet-ZZZZ", "subnet-YYYY"] # List of private subnets (matching AZs) where to deploy the cluster (required if existing VPC is used)
 
+k8s_aws_ssh_keypair_name = "" # Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified)
+
 logs_not_resource = [] # List of resources that log police will use for NotResource, empty means that Resource * is set
 
 operations_aws_account_number = "123456789012" # AWS operations account number (without hyphens)


### PR DESCRIPTION
The variable is supported in operations, application and kops modules. It is especially useful on application account because cluster gets deployed there from temporary jx pods that get destroyed afterwards along with ssh keys generated inside.
When not specified or empty, SSH keys will be generated by kops module.