### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/application/eu-central-1/env/main.tf
+++ b/application/eu-central-1/env/main.tf
@@ -13,6 +13,7 @@ module "application" {
   k8s_master_instance_type = "${var.k8s_master_instance_type}"
   k8s_node_instance_type   = "${var.k8s_node_instance_type}"
   k8s_aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
+  k8s_linux_distro         = "${var.k8s_linux_distro}"
 
   iam_cross_account_role_arn    = "${var.iam_cross_account_role_arn}"
   k8s_masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"

--- a/application/eu-central-1/env/variables.tf
+++ b/application/eu-central-1/env/variables.tf
@@ -31,3 +31,5 @@ variable "k8s_master_instance_type" {}
 variable "k8s_node_instance_type" {}
 
 variable "k8s_aws_ssh_keypair_name" {}
+
+variable "k8s_linux_distro" {}

--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -167,6 +167,8 @@ k8s_node_count = "3"
 k8s_aws_ssh_keypair_name = ""
 
 # Linux distribution for K8s cluster instances (supported values: debian, amzn2)
+# Example:
+# k8s_linux_distro = "debian"
 
 k8s_linux_distro = "debian"
 

--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -168,7 +168,7 @@ k8s_aws_ssh_keypair_name = ""
 
 # Linux distribution for K8s cluster instances (supported values: debian, amzn2)
 
-k8s_linux_distro = "amzn2"
+k8s_linux_distro = "debian"
 
 ###############################################################################
 # Operations account configuration

--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -166,6 +166,10 @@ k8s_node_count = "3"
 
 k8s_aws_ssh_keypair_name = ""
 
+# Linux distribution for K8s cluster instances (supported values: debian, amzn2)
+
+k8s_linux_distro = "amzn2"
+
 ###############################################################################
 # Operations account configuration
 ###############################################################################

--- a/operations/eu-central-1/env/main.tf
+++ b/operations/eu-central-1/env/main.tf
@@ -14,6 +14,7 @@ module "operations" {
   k8s_master_instance_type = "${var.k8s_master_instance_type}"
   k8s_node_instance_type   = "${var.k8s_node_instance_type}"
   k8s_aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
+  k8s_linux_distro         = "${var.k8s_linux_distro}"
 
   k8s_masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"
   k8s_nodes_iam_policies_arns   = "${var.k8s_nodes_iam_policies_arns}"

--- a/operations/eu-central-1/env/variables.tf
+++ b/operations/eu-central-1/env/variables.tf
@@ -33,3 +33,5 @@ variable "k8s_nodes_iam_policies_arns" {
 }
 
 variable "k8s_aws_ssh_keypair_name" {}
+
+variable "k8s_linux_distro" {}

--- a/operations/eu-central-1/terraform.tfvars
+++ b/operations/eu-central-1/terraform.tfvars
@@ -242,4 +242,4 @@ k8s_aws_ssh_keypair_name = ""
 
 # Linux distribution for K8s cluster instances (supported values: debian, amzn2)
 
-k8s_linux_distro = "amzn2"
+k8s_linux_distro = "debian"

--- a/operations/eu-central-1/terraform.tfvars
+++ b/operations/eu-central-1/terraform.tfvars
@@ -241,5 +241,7 @@ k8s_node_count = "3"
 k8s_aws_ssh_keypair_name = ""
 
 # Linux distribution for K8s cluster instances (supported values: debian, amzn2)
+# Example:
+# k8s_linux_distro = "debian"
 
 k8s_linux_distro = "debian"

--- a/operations/eu-central-1/terraform.tfvars
+++ b/operations/eu-central-1/terraform.tfvars
@@ -239,3 +239,7 @@ k8s_node_count = "3"
 # instances (will be generated if not specified)
 
 k8s_aws_ssh_keypair_name = ""
+
+# Linux distribution for K8s cluster instances (supported values: debian, amzn2)
+
+k8s_linux_distro = "amzn2"


### PR DESCRIPTION
Based on new feature in kops module: kentrikos/terraform-aws-kops#6