### PR TITLE
Add new parameter for R53 HostedZoneID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added new parameter for R53 HostedZoneID
 
 ## [0.4.1] - 2019-03-26
 ### Fixed
@@ -24,16 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated jenkins core module to 0.4.2 with fixed job names
 
 ## [0.3.2] - 2019-03-20
-## Changed
+### Changed
 - Updated `terraform-aws-operations-account` module to v0.3.1
 - Updated `terraform-aws-application-account` module to v0.3.1
-## Added
+### Added
 - Inputs to enable autoscaling features of deployed cluster
 - Input to enable helm installation
 - Input for cluster tagging on cluster (Application environment)
 
 ## [0.3.1] - 2019-03-11
-## Changed
+### Changed
 - Updated `terraform-aws-bootstrap-jenkins` module to v0.3.1
 
 ## [0.3.0] - 2019-03-07

--- a/operations/eu-central-1/env-eks/jenkins/parameters.yaml
+++ b/operations/eu-central-1/env-eks/jenkins/parameters.yaml
@@ -31,13 +31,28 @@ gitBitbucketServer: ''
 # defaultAdminPassword: 'qwerty'
 defaultAdminPassword: 'qwerty'
 
-# jxHostedZoneID is an AWS Route53 parameter to store Domain for Jx
+# domainHostedZoneID is an AWS Route53 parameter to store Domain used e.g. for LMA
+# Example:
+# domainHostedZoneID: 'Z9NMCFPV6TPZZR'
+
+domainHostedZoneID: ''
+
+# domainAliasPrefix is a string for wildcard alias that will be created (e.g. for LMA ingress)
+# Example:
+# domainAliasPrefix: 'demoapp'
+
+domainAliasPrefix: 'demoapp'
+
+# jxDomainHostedZoneID is an AWS Route53 parameter to store Domain for Jx
+# This is for backward compatibility with (experimental) jx support.
 # Example:
 # jxDomainHostedZoneID: 'Z9NMCFPV6TPZZR'
 
 jxDomainHostedZoneID: ''
 
 # jxDomainAliasPrefix is a string for wildcard alias that will be created (*.jxDomainAliasPrefix.DOMAIN)
+# This is for backward compatibility with (experimental) jx support.
 # Example:
 # jxDomainAliasPrefix: 'demoapp'
+
 jxDomainAliasPrefix: 'demoapp'

--- a/operations/eu-central-1/env-kops/jenkins/parameters.yaml
+++ b/operations/eu-central-1/env-kops/jenkins/parameters.yaml
@@ -31,13 +31,28 @@ gitBitbucketServer: ''
 # defaultAdminPassword: 'qwerty'
 defaultAdminPassword: 'qwerty'
 
-# jxHostedZoneID is an AWS Route53 parameter to store Domain for Jx
+# domainHostedZoneID is an AWS Route53 parameter to store Domain used e.g. for LMA
+# Example:
+# domainHostedZoneID: 'Z9NMCFPV6TPZZR'
+
+domainHostedZoneID: ''
+
+# domainAliasPrefix is a string for wildcard alias that will be created (e.g. for LMA ingress)
+# Example:
+# domainAliasPrefix: 'demoapp'
+
+domainAliasPrefix: 'demoapp'
+
+# jxDomainHostedZoneID is an AWS Route53 parameter to store Domain for Jx
+# This is for backward compatibility with (experimental) jx support.
 # Example:
 # jxDomainHostedZoneID: 'Z9NMCFPV6TPZZR'
 
 jxDomainHostedZoneID: ''
 
 # jxDomainAliasPrefix is a string for wildcard alias that will be created (*.jxDomainAliasPrefix.DOMAIN)
+# This is for backward compatibility with (experimental) jx support.
 # Example:
 # jxDomainAliasPrefix: 'demoapp'
+
 jxDomainAliasPrefix: 'demoapp'


### PR DESCRIPTION
A quick fix to improve readability when configuring R53 domains for Kentrikos.