### PR TITLE
Update documentation on limitation in product domain name length

### DIFF
--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -80,13 +80,25 @@ auto_IAM_path = "/"
 logs_not_resource = []
 
 # The following settings will configure tags and names in the deployment, e.g.
-# for EC2 instance name tags. Examples:
+# for EC2 instance name tags. 
+#
+# IMPORTANT NOTE:
+# The combination of region - product_domain_name - environment_type cannot be longer than 32 chars
+# Examples: 
+#   eu-central-1-long-product-domain-name-test = 43 chars
+#   eu-central-1-product-domain-name-test = 38 chars
+#   eu-central-1-productdomain-test = 32 chars
+#
+# otherwise your deployment will fail:
+# 
+# Examples:
 # environment_type = "test"
 # product_domain_name = "demo"
 
 environment_type = "test"
 
 product_domain_name = "demo"
+
 
 # IMPORTANT NOTE: Currently only one or three availability zones are supported.
 #

--- a/application/eu-central-1/terraform.tfvars
+++ b/application/eu-central-1/terraform.tfvars
@@ -99,7 +99,6 @@ environment_type = "test"
 
 product_domain_name = "demo"
 
-
 # IMPORTANT NOTE: Currently only one or three availability zones are supported.
 #
 # Parameters to configure the network for your deployment. Enter the target AWS

--- a/operations/eu-central-1/terraform.tfvars
+++ b/operations/eu-central-1/terraform.tfvars
@@ -90,7 +90,18 @@ auto_IAM_path = "/"
 logs_not_resource = []
 
 # The following settings will configure tags and names in the deployment, e.g.
-# for EC2 instance name tags. Examples:
+# for EC2 instance name tags. 
+#
+# IMPORTANT NOTE:
+# The combination of region - product_domain_name - environment_type cannot be longer than 32 chars
+# Examples: 
+#   eu-central-1-long-product-domain-name-test = 43 chars
+#   eu-central-1-product-domain-name-test = 38 chars
+#   eu-central-1-productdomain-test = 32 chars
+#
+# otherwise your deployment will fail:
+# 
+# Examples:
 # environment_type = "test"
 # product_domain_name = "demo"
 


### PR DESCRIPTION
The combination of region - product_domain_name - environment_type cannot be longer than 32 chars, otherwise your deployment will fail:

Error: module.application.module.kubernetes_cluster_application.module.eks.aws_iam_role.cluster: "name_prefix" cannot be longer than 32 characters, name is limited to 64

https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/cluster.tf

resource "aws_iam_role" "cluster" {
  count                 = var.manage_cluster_iam_resources ? 1 : 0
  name_prefix           = var.cluster_name

cluster_name = "${var.region}-${var.product_domain_name}-${var.environment_type}" < 33 Chars
